### PR TITLE
Bump GCC to version 8

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,7 +29,7 @@ linux_task:
               CXX: clang++
         - name: linux_gcc
           container:
-              image: gcc:7
+              image: gcc:8
     test_script: make -j4 test
     env:
         LC_ALL: en_US.UTF-8
@@ -42,7 +42,7 @@ macos_task:
           env:
               CXX: clang++
         - name: macos_gcc
-          gcc_script: brew install gcc@7
+          gcc_script: brew install gcc@8
           env:
-              CXX: g++-7
+              CXX: g++-8
     test_script: make -j4 test


### PR DESCRIPTION
Given the recent commit https://github.com/mawww/kakoune/commit/874b72a63c53712f0b438495b82a8337984da2a6 which bumped the minimum required GCC version to 8, this PR just updates the CI configuration to use GCC 8 instead of 7.

This will hopefully make builds green again. 